### PR TITLE
Fix link rights

### DIFF
--- a/inc/change_release.class.php
+++ b/inc/change_release.class.php
@@ -49,8 +49,6 @@ class PluginReleasesChange_Release extends CommonDBRelation {
    static public $itemtype_2 = 'PluginReleasesRelease';
    static public $items_id_2 = 'plugin_releases_releases_id';
 
-   static $rightname = 'plugin_releases_releases';
-
    static function getTypeName($nb = 0) {
       return _n('Link Release/Change', 'Links Release/Change', $nb, 'releases');
    }
@@ -224,24 +222,6 @@ class PluginReleasesChange_Release extends CommonDBRelation {
     **/
    function post_purgeItem() {
       //TODO
-   }
-
-   static function canCreate() {
-      return Session::haveRight(static::$rightname, UPDATE);
-   }
-
-
-   /**
-    * Have I the global right to "view" the Object
-    *
-    * Default is true and check entity if the objet is entity assign
-    *
-    * May be overloaded if needed
-    *
-    * @return booleen
-    **/
-   static function canView() {
-      return Session::haveRight(static::$rightname, READ);
    }
 
    static function showReleaseFromChange($item) {


### PR DESCRIPTION
A client wanted to avoid giving purge rights on Releases to users just to unlink changes from releases.

When no rightname is specified for a CommonDBRelation class, it defaults to checking update permissions on both sides of the link. The same is done when creating links. I did not see a need to override the default permission checks for this link class, but please let me know if I missed something.